### PR TITLE
Add Compass component config (compass.yml)

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,8 @@
+name: django-piston
+id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/89dc62ff-6f34-4906-83e2-faea3ec90a61
+configVersion: 1
+typeId: OTHER
+ownerId: ari:cloud:identity::team/02623aed-f05b-4acd-8187-7932552722de-12 # Video - Storage Services (253)
+links:
+  - type: REPOSITORY
+    url: https://github.com/EENCloud/django-piston


### PR DESCRIPTION
Onboards `django-piston` to Compass (replaces the stale compass-github-importer PR).

- typeId: `OTHER`
- owner: Video - Storage Services (253)
- component: `89dc62ff-6f34-4906-83e2-faea3ec90a61`