### PR TITLE
CODEOWNERS: owning team Video - Storage Services (253)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: Video - Storage Services (253).
+* @EENCloud/video-storage-services-253


### PR DESCRIPTION
Ensures **django-piston** has a CODEOWNERS file naming its owning team **Video - Storage Services (253)** (`@EENCloud/video-storage-services-253`).

**Changes:** create .github/CODEOWNERS (@EENCloud/video-storage-services-253)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
