### PR TITLE
fix(compass): add/correct slug fields

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,5 +1,6 @@
 name: django-piston
 id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/89dc62ff-6f34-4906-83e2-faea3ec90a61
+slug: django-piston
 configVersion: 1
 typeId: OTHER
 ownerId: ari:cloud:identity::team/02623aed-f05b-4acd-8187-7932552722de-12 # Video - Storage Services (253)


### PR DESCRIPTION
## Summary

Adds or corrects `slug:` fields in compass.yml file(s). The slug is derived from the component `name:` field, kebab-cased — the canonical form Compass uses internally. Using the name (rather than the repo name) handles monorepos naturally: each component in a repo has its own distinct name and therefore its own unique slug.

- `compass.yml`: add `slug: django-piston`

🤖 Generated by `scripts/fix-compass-slugs.js`